### PR TITLE
Uri fix

### DIFF
--- a/mediaplayer/src/jvmMain/kotlin/io/github/kdroidfilter/composemediaplayer/javafx/JavaFxVideoPlayerState.kt
+++ b/mediaplayer/src/jvmMain/kotlin/io/github/kdroidfilter/composemediaplayer/javafx/JavaFxVideoPlayerState.kt
@@ -97,10 +97,7 @@ class JavaFxVideoPlayerState : PlatformVideoPlayerState {
                 Thread.sleep(100)
 
                 // Créer le nouveau MediaPlayer
-                val fileOrUrl = if (uri.startsWith("http")) uri else File(uri).toURI().toString()
-                println("Opening media: $fileOrUrl")
-
-                val media = Media(fileOrUrl)
+                val media = Media(uri)
                 MediaPlayer(media).also { player ->
                     mediaPlayer = player
                     setupMediaPlayer(player)

--- a/mediaplayer/src/jvmMain/kotlin/io/github/kdroidfilter/composemediaplayer/linux/LinuxVideoPlayerState.kt
+++ b/mediaplayer/src/jvmMain/kotlin/io/github/kdroidfilter/composemediaplayer/linux/LinuxVideoPlayerState.kt
@@ -314,7 +314,6 @@ class LinuxVideoPlayerState : PlatformVideoPlayerState {
         _hasMedia = false
 
         try {
-            println("Opening URI: $uri")
             val uriObj = URI(uri)
             playbin.setURI(uriObj)
             _hasMedia = true
@@ -329,7 +328,6 @@ class LinuxVideoPlayerState : PlatformVideoPlayerState {
     }
 
     override fun play() {
-        println("Playing video")
         try {
             playbin.play()
             playbin.set("volume", volume.toDouble())
@@ -338,7 +336,6 @@ class LinuxVideoPlayerState : PlatformVideoPlayerState {
             isUserPaused = false
             updateLoadingState()
         } catch (e: Exception) {
-            e.printStackTrace()
             _error = VideoPlayerError.UnknownError("Failed to play: ${e.message}")
             _isPlaying = false
         }

--- a/mediaplayer/src/jvmMain/kotlin/io/github/kdroidfilter/composemediaplayer/linux/LinuxVideoPlayerState.kt
+++ b/mediaplayer/src/jvmMain/kotlin/io/github/kdroidfilter/composemediaplayer/linux/LinuxVideoPlayerState.kt
@@ -314,11 +314,8 @@ class LinuxVideoPlayerState : PlatformVideoPlayerState {
         _hasMedia = false
 
         try {
-            val uriObj = if (uri.startsWith("http://") || uri.startsWith("https://")) {
-                URI(uri)
-            } else {
-                File(uri).toURI()
-            }
+            println("Opening URI: $uri")
+            val uriObj = URI(uri)
             playbin.setURI(uriObj)
             _hasMedia = true
             play() // This will set _isPlaying to true if successful
@@ -332,6 +329,7 @@ class LinuxVideoPlayerState : PlatformVideoPlayerState {
     }
 
     override fun play() {
+        println("Playing video")
         try {
             playbin.play()
             playbin.set("volume", volume.toDouble())
@@ -340,6 +338,7 @@ class LinuxVideoPlayerState : PlatformVideoPlayerState {
             isUserPaused = false
             updateLoadingState()
         } catch (e: Exception) {
+            e.printStackTrace()
             _error = VideoPlayerError.UnknownError("Failed to play: ${e.message}")
             _isPlaying = false
         }

--- a/mediaplayer/src/jvmMain/kotlin/io/github/kdroidfilter/composemediaplayer/windows/compose/WindowsVideoPlayerState.kt
+++ b/mediaplayer/src/jvmMain/kotlin/io/github/kdroidfilter/composemediaplayer/windows/compose/WindowsVideoPlayerState.kt
@@ -183,19 +183,8 @@ class WindowsVideoPlayerState : PlatformVideoPlayerState {
         resetState()
 
         try {
-            logger.log("Opening URI: $uri") // Ajout de log
-            val hr = when {
-                uri.startsWith("http", ignoreCase = true) -> {
-                    logger.log("Playing URL: $uri")
-                    mediaPlayer.PlayURL(WString(uri))
-                }
-                else -> {
-                    val file = File(uri)
-                    if (!file.exists()) throw FileNotFoundException("File not found: $uri")
-                    logger.log("Playing file: ${file.absolutePath}")
-                    mediaPlayer.PlayFile(WString(file.absolutePath))
-                }
-            }
+            logger.log("Playing URL: $uri")
+            val hr = mediaPlayer.PlayURL(WString(uri))
             logger.log("PlayFile/URL returned HR=0x${hr.toString(16)}") // Ajout de log
             if (hr < 0) {
                 handleError("Unable to open (HR=0x${hr.toString(16)})")

--- a/sample/composeApp/src/androidMain/kotlin/sample/app/App.android.kt
+++ b/sample/composeApp/src/androidMain/kotlin/sample/app/App.android.kt
@@ -6,6 +6,6 @@ import io.github.vinceglb.filekit.PlatformFile
 actual fun PlatformFile.getUri(): String {
     return when (val androidFile = this.androidFile) {
         is AndroidFile.UriWrapper -> androidFile.uri.toString()
-        is AndroidFile.FileWrapper -> "file://${androidFile.file.absolutePath}"
+        is AndroidFile.FileWrapper -> androidFile.file.toURI().toString()
     }
 }

--- a/sample/composeApp/src/androidMain/kotlin/sample/app/App.android.kt
+++ b/sample/composeApp/src/androidMain/kotlin/sample/app/App.android.kt
@@ -6,6 +6,6 @@ import io.github.vinceglb.filekit.PlatformFile
 actual fun PlatformFile.getUri(): String {
     return when (val androidFile = this.androidFile) {
         is AndroidFile.UriWrapper -> androidFile.uri.toString()
-        is AndroidFile.FileWrapper -> androidFile.file.path
+        is AndroidFile.FileWrapper -> "file://${androidFile.file.absolutePath}"
     }
 }

--- a/sample/composeApp/src/commonMain/kotlin/sample/app/App.kt
+++ b/sample/composeApp/src/commonMain/kotlin/sample/app/App.kt
@@ -36,7 +36,7 @@ fun App() {
             title = "Select a Video File",
             onResult = { file ->
                 file?.let { url = it.getUri() }
-                // file?.let { playerState.openFile(it) }
+                // Or: file?.let { playerState.openFile(it) }
                 // Or: file?.let { playerState.openUri(it.getUri()) }
             }
         )

--- a/sample/composeApp/src/commonMain/kotlin/sample/app/App.kt
+++ b/sample/composeApp/src/commonMain/kotlin/sample/app/App.kt
@@ -35,7 +35,8 @@ fun App() {
             type = PickerType.Video,
             title = "Select a Video File",
             onResult = { file ->
-                file?.let { playerState.openFile(it) }
+                file?.let { url = it.getUri() }
+                // file?.let { playerState.openFile(it) }
                 // Or: file?.let { playerState.openUri(it.getUri()) }
             }
         )

--- a/sample/composeApp/src/jvmMain/kotlin/sample/app/App.jvm.kt
+++ b/sample/composeApp/src/jvmMain/kotlin/sample/app/App.jvm.kt
@@ -4,5 +4,5 @@ import io.github.vinceglb.filekit.PlatformFile
 import io.github.vinceglb.filekit.path
 
 actual fun PlatformFile.getUri(): String {
-    return this.path.toString()
+    return "file://$path"
 }

--- a/sample/composeApp/src/jvmMain/kotlin/sample/app/App.jvm.kt
+++ b/sample/composeApp/src/jvmMain/kotlin/sample/app/App.jvm.kt
@@ -1,8 +1,7 @@
 package sample.app
 
 import io.github.vinceglb.filekit.PlatformFile
-import io.github.vinceglb.filekit.path
 
 actual fun PlatformFile.getUri(): String {
-    return "file://$path"
+    return file.toURI().toString()
 }


### PR DESCRIPTION
Only accept valid URIs in `openUri`. This was already correct on Android. On Linux and other platform, it broke playback of valid URIs.