### PR TITLE
FileKit 0.10 upgrade and remove snapshot version

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -45,17 +45,6 @@ dependencies {
 ```
 
 > [!IMPORTANT]
->It is necessary (for now) to add the following Maven repository to your dependencies because Compose Media Player relies on a snapshot version of the [FileKt core](https://github.com/vinceglb/FileKit/tree/main/filekit-core):
-
-```kotlin
-repositories {
-    maven("https://s01.oss.sonatype.org/content/repositories/snapshots/")
-}
-```
-
-For more information, visit: [FileKt on GitHub](https://github.com/vinceglb/FileKit/)
-
-> [!IMPORTANT]
 > Currently, you also need to manually include JavaFX dependencies if your application is also intended for macOS.
 
 ```kotlin
@@ -121,8 +110,14 @@ You can play a video by providing a direct URL:
 playerState.openUri("http://example.com/video.mp4")
 ```
 
-To play a local video file, please refer to [example](sample/composeApp/src/commonMain/kotlin/sample/app/App.kt) using [FileKt](https://github.com/vinceglb/FileKit).
+To play a local video file you can use [PlatformFile](https://filekit.mintlify.app/core/platform-file) from [FileKit](https://github.com/vinceglb/FileKit).
 
+```kotlin
+val file = FileKit.openFilePicker(type = FileKitType.Video)
+file?.let { playerState.openFile(file) }
+```
+
+Check the [sample project](sample/composeApp/src/commonMain/kotlin/sample/app/App.kt) for a complete example.
 
 ### Full Controls
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,11 +1,11 @@
 [versions]
 
 androidcontextprovider = "1.0.1"
-filekit = "0.10.0-SNAPSHOT"
+filekit = "0.10.0-beta01"
 gst1JavaCore = "1.4.0"
 gst1JavaSwing = "0.9.0"
 kotlin = "2.1.10"
-agp = "8.7.3"
+agp = "8.8.2"
 kotlinLogging = "7.0.4"
 kotlinx-coroutines = "1.10.1"
 kotlinxBrowserWasmJs = "0.3"
@@ -24,7 +24,7 @@ androidcontextprovider = { module = "io.github.kdroidfilter:androidcontextprovid
 androidx-media3-exoplayer = { module = "androidx.media3:media3-exoplayer", version.ref = "media3Exoplayer" }
 androidx-media3-ui = { module = "androidx.media3:media3-ui", version.ref = "media3Exoplayer" }
 filekit-core = { module = "io.github.vinceglb:filekit-core", version.ref = "filekit" }
-filekit-dialog-compose = { module = "io.github.vinceglb:filekit-dialog-compose", version.ref = "filekit" }
+filekit-dialogs-compose = { module = "io.github.vinceglb:filekit-dialogs-compose", version.ref = "filekit" }
 gst1-java-core = { module = "org.freedesktop.gstreamer:gst1-java-core", version.ref = "gst1JavaCore" }
 gst1-java-swing = { module = "org.freedesktop.gstreamer:gst1-java-swing", version.ref = "gst1JavaSwing" }
 kotlin-logging = { module = "io.github.oshai:kotlin-logging", version.ref = "kotlinLogging" }

--- a/sample/composeApp/build.gradle.kts
+++ b/sample/composeApp/build.gradle.kts
@@ -68,7 +68,7 @@ kotlin {
             implementation(compose.material3)
             implementation(project(":mediaplayer"))
             implementation(compose.materialIconsExtended)
-            implementation(libs.filekit.dialog.compose)
+            implementation(libs.filekit.dialogs.compose)
         }
 
         androidMain.dependencies {

--- a/sample/composeApp/src/androidMain/kotlin/sample/app/main.kt
+++ b/sample/composeApp/src/androidMain/kotlin/sample/app/main.kt
@@ -4,7 +4,7 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import io.github.vinceglb.filekit.FileKit
-import io.github.vinceglb.filekit.dialog.init
+import io.github.vinceglb.filekit.dialogs.init
 
 class AppActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/sample/composeApp/src/commonMain/kotlin/sample/app/App.kt
+++ b/sample/composeApp/src/commonMain/kotlin/sample/app/App.kt
@@ -31,8 +31,8 @@ import io.github.kdroidfilter.composemediaplayer.VideoPlayerError
 import io.github.kdroidfilter.composemediaplayer.VideoPlayerSurface
 import io.github.kdroidfilter.composemediaplayer.rememberVideoPlayerState
 import io.github.kdroidfilter.composemediaplayer.util.getUri
-import io.github.vinceglb.filekit.dialog.PickerType
-import io.github.vinceglb.filekit.dialog.compose.rememberFilePickerLauncher
+import io.github.vinceglb.filekit.dialogs.FileKitType
+import io.github.vinceglb.filekit.dialogs.compose.rememberFilePickerLauncher
 import io.github.vinceglb.filekit.name
 
 @Composable
@@ -48,7 +48,7 @@ fun App() {
 
         // Launcher for selecting a local video file
         val videoFileLauncher = rememberFilePickerLauncher(
-            type = PickerType.Video,
+            type = FileKitType.Video,
             title = "Select a video"
         ) { file ->
             file?.let {
@@ -58,13 +58,13 @@ fun App() {
 
         // Launcher for selecting a local subtitle file (VTT format)
         val subtitleFileLauncher = rememberFilePickerLauncher(
-            type = PickerType.File(extensions = listOf("vtt")),
+            type = FileKitType.File("vtt"),
             title = "Select a subtitle file"
         ) { file ->
             file?.let {
                 val subtitleUri = it.getUri()
                 val track = SubtitleTrack(
-                    label = it.name ?: "Local",
+                    label = it.name,
                     language = "en",
                     src = subtitleUri
                 )


### PR DESCRIPTION
I finally published a beta version of FileKit 0.10.

By upgrading to this version, it removes the need to set up snapshots when implementing the library.

Let me know if you have any comments!