### PR TITLE
Refine video loading and playback control logic

### DIFF
--- a/mediaplayer/src/iosMain/kotlin/io/github/kdroidfilter/composemediaplayer/VideoPlayerSurface.ios.kt
+++ b/mediaplayer/src/iosMain/kotlin/io/github/kdroidfilter/composemediaplayer/VideoPlayerSurface.ios.kt
@@ -81,10 +81,11 @@ actual fun VideoPlayerSurface(playerState: VideoPlayerState, modifier: Modifier)
                     containerView.layoutIfNeeded()
                     avPlayerViewController.view.setFrame(containerView.bounds)
 
-                    // Start playback if media is loaded and not already playing
-                    if (playerState.player != null && playerState.hasMedia) {
+                    // Only start playback if media is loaded, not already playing, and user hasn't paused
+                    if (playerState.player != null && playerState.hasMedia && !playerState.isPlaying) {
                         Logger.d { "Starting playback" }
-                        playerState.play()
+                        // Don't automatically play - let the user control playback
+                        // playerState.play()
                     }
                 }
             )


### PR DESCRIPTION
### Description

This pull request introduces improvements to the video playback logic:
- Added an `_isLoading` state to manage loading events during video setup and seeking.
- Enhanced playback control to prevent automatic play, giving users more control over video playback.

### Checklist

- [x] Code compiles correctly
- [x] Tests for the changes have been added (if applicable)
- [x] All existing and new tests pass