### PR TITLE
Add CocoaPods support for iOS integration

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     alias(libs.plugins.multiplatform).apply(false)
     alias(libs.plugins.android.library).apply(false)
     alias(libs.plugins.android.application).apply(false)
+    alias(libs.plugins.kotlinCocoapods) apply false
     alias(libs.plugins.dokka).apply(false)
     alias(libs.plugins.vannitktech.maven.publish).apply(false)
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,7 @@
 [versions]
 
 androidcontextprovider = "1.0.1"
+cocoapods = "1.9.0"
 filekit = "0.10.0-beta03"
 gst1JavaCore = "1.4.0"
 kermit = "2.0.5"
@@ -41,6 +42,7 @@ slf4j-simple = { module = "org.slf4j:slf4j-simple", version.ref = "slf4jSimple" 
 [plugins]
 
 multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
+kotlinCocoapods = { id = "org.jetbrains.kotlin.native.cocoapods", version.ref = "kotlin" }
 android-library = { id = "com.android.library", version.ref = "agp" }
 compose = { id = "org.jetbrains.compose", version.ref = "compose" }
 compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }

--- a/mediaplayer/build.gradle.kts
+++ b/mediaplayer/build.gradle.kts
@@ -3,6 +3,7 @@
 import com.vanniktech.maven.publish.SonatypeHost
 import org.jetbrains.dokka.gradle.DokkaTask
 import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
+import org.jetbrains.kotlin.gradle.plugin.mpp.NativeBuildType
 
 plugins {
     alias(libs.plugins.multiplatform)
@@ -11,6 +12,7 @@ plugins {
     alias(libs.plugins.compose)
     alias(libs.plugins.vannitktech.maven.publish)
     alias(libs.plugins.dokka)
+    alias(libs.plugins.kotlinCocoapods)
 }
 
 group = "io.github.kdroidfilter.composemediaplayer"
@@ -39,6 +41,24 @@ kotlin {
     iosX64()
     iosArm64()
     iosSimulatorArm64()
+
+
+    cocoapods {
+        version = version.toString()
+        summary = "A multiplatform video player library for Compose applications"
+        homepage = "https://github.com/kdroidFilter/Compose-Media-Player"
+        name = "ComposeMediaPlayer"
+
+        framework {
+            baseName = "ComposeMediaPlayer"
+            isStatic = false
+            transitiveExport = false // This is default.
+        }
+
+        // Maps custom Xcode configuration to NativeBuildType
+        xcodeConfigurationToNativeBuildType["CUSTOM_DEBUG"] = NativeBuildType.DEBUG
+        xcodeConfigurationToNativeBuildType["CUSTOM_RELEASE"] = NativeBuildType.RELEASE
+    }
 
     sourceSets {
         commonMain.dependencies {


### PR DESCRIPTION
Adds CocoaPods plugin configuration to support iOS platform in the multiplatform project. Configures framework settings, metadata, and custom Xcode build options for ComposeMediaPlayer.