### PR TITLE
Refine video player frame processing and cleanup logic

### DIFF
--- a/mediaplayer/src/jvmMain/kotlin/io/github/kdroidfilter/composemediaplayer/linux/LinuxFrameUtils.kt
+++ b/mediaplayer/src/jvmMain/kotlin/io/github/kdroidfilter/composemediaplayer/linux/LinuxFrameUtils.kt
@@ -1,0 +1,90 @@
+package io.github.kdroidfilter.composemediaplayer.linux
+
+import java.nio.ByteBuffer
+
+/**
+ * Calculates a fast hash of the frame buffer to detect frame changes.
+ * Samples approximately 200 pixels evenly distributed across the frame.
+ *
+ * @param buffer The source buffer containing RGBA pixel data
+ * @param pixelCount Total number of pixels in the frame
+ * @return A hash value representing the frame content
+ */
+internal fun calculateFrameHash(buffer: ByteBuffer, pixelCount: Int): Int {
+    if (pixelCount <= 0) return 0
+
+    var hash = 1
+    val step = if (pixelCount <= 200) 1 else pixelCount / 200
+    for (i in 0 until pixelCount step step) {
+        hash = 31 * hash + buffer.getInt(i * 4)
+    }
+    return hash
+}
+
+/**
+ * Copies RGBA frame data from source to destination buffer with minimal overhead.
+ * Handles row padding when destination stride differs from source.
+ *
+ * This function performs a single memory copy operation when strides match,
+ * achieving zero-copy performance (beyond the necessary single copy from
+ * GStreamer buffer to Skia bitmap).
+ *
+ * @param src Source buffer containing RGBA pixel data from GStreamer
+ * @param dst Destination buffer (Skia bitmap pixels via peekPixels)
+ * @param width Frame width in pixels
+ * @param height Frame height in pixels
+ * @param dstRowBytes Destination row stride (may include padding)
+ */
+internal fun copyRgbaFrame(
+    src: ByteBuffer,
+    dst: ByteBuffer,
+    width: Int,
+    height: Int,
+    dstRowBytes: Int,
+) {
+    require(width > 0) { "width must be > 0 (was $width)" }
+    require(height > 0) { "height must be > 0 (was $height)" }
+    val srcRowBytes = width * 4
+    require(dstRowBytes >= srcRowBytes) {
+        "dstRowBytes ($dstRowBytes) must be >= srcRowBytes ($srcRowBytes)"
+    }
+
+    val requiredSrcBytes = srcRowBytes.toLong() * height.toLong()
+    val requiredDstBytes = dstRowBytes.toLong() * height.toLong()
+    require(src.capacity().toLong() >= requiredSrcBytes) {
+        "src buffer too small: ${src.capacity()} < $requiredSrcBytes"
+    }
+    require(dst.capacity().toLong() >= requiredDstBytes) {
+        "dst buffer too small: ${dst.capacity()} < $requiredDstBytes"
+    }
+
+    val srcBuf = src.duplicate()
+    val dstBuf = dst.duplicate()
+    srcBuf.rewind()
+    dstBuf.rewind()
+
+    // Fast path: when strides match, do a single bulk copy
+    if (dstRowBytes == srcRowBytes) {
+        srcBuf.limit(requiredSrcBytes.toInt())
+        dstBuf.limit(requiredSrcBytes.toInt())
+        dstBuf.put(srcBuf)
+        return
+    }
+
+    // Slow path: copy row by row when there's padding
+    val srcCapacity = srcBuf.capacity()
+    val dstCapacity = dstBuf.capacity()
+    for (row in 0 until height) {
+        val srcPos = row * srcRowBytes
+        srcBuf.limit(srcCapacity)
+        srcBuf.position(srcPos)
+        srcBuf.limit(srcPos + srcRowBytes)
+
+        val dstPos = row * dstRowBytes
+        dstBuf.limit(dstCapacity)
+        dstBuf.position(dstPos)
+        dstBuf.limit(dstPos + srcRowBytes)
+
+        dstBuf.put(srcBuf)
+    }
+}

--- a/mediaplayer/src/jvmMain/kotlin/io/github/kdroidfilter/composemediaplayer/mac/MacFrameUtils.kt
+++ b/mediaplayer/src/jvmMain/kotlin/io/github/kdroidfilter/composemediaplayer/mac/MacFrameUtils.kt
@@ -1,0 +1,66 @@
+package io.github.kdroidfilter.composemediaplayer.mac
+
+import java.nio.ByteBuffer
+
+internal fun calculateFrameHash(buffer: ByteBuffer, pixelCount: Int): Int {
+    if (pixelCount <= 0) return 0
+
+    var hash = 1
+    val step = if (pixelCount <= 200) 1 else pixelCount / 200
+    for (i in 0 until pixelCount step step) {
+        hash = 31 * hash + buffer.getInt(i * 4)
+    }
+    return hash
+}
+
+internal fun copyBgraFrame(
+    src: ByteBuffer,
+    dst: ByteBuffer,
+    width: Int,
+    height: Int,
+    dstRowBytes: Int,
+) {
+    require(width > 0) { "width must be > 0 (was $width)" }
+    require(height > 0) { "height must be > 0 (was $height)" }
+    val srcRowBytes = width * 4
+    require(dstRowBytes >= srcRowBytes) {
+        "dstRowBytes ($dstRowBytes) must be >= srcRowBytes ($srcRowBytes)"
+    }
+
+    val requiredSrcBytes = srcRowBytes.toLong() * height.toLong()
+    val requiredDstBytes = dstRowBytes.toLong() * height.toLong()
+    require(src.capacity().toLong() >= requiredSrcBytes) {
+        "src buffer too small: ${src.capacity()} < $requiredSrcBytes"
+    }
+    require(dst.capacity().toLong() >= requiredDstBytes) {
+        "dst buffer too small: ${dst.capacity()} < $requiredDstBytes"
+    }
+
+    val srcBuf = src.duplicate()
+    val dstBuf = dst.duplicate()
+    srcBuf.rewind()
+    dstBuf.rewind()
+
+    if (dstRowBytes == srcRowBytes) {
+        srcBuf.limit(requiredSrcBytes.toInt())
+        dstBuf.limit(requiredSrcBytes.toInt())
+        dstBuf.put(srcBuf)
+        return
+    }
+
+    val srcCapacity = srcBuf.capacity()
+    val dstCapacity = dstBuf.capacity()
+    for (row in 0 until height) {
+        val srcPos = row * srcRowBytes
+        srcBuf.limit(srcCapacity)
+        srcBuf.position(srcPos)
+        srcBuf.limit(srcPos + srcRowBytes)
+
+        val dstPos = row * dstRowBytes
+        dstBuf.limit(dstCapacity)
+        dstBuf.position(dstPos)
+        dstBuf.limit(dstPos + srcRowBytes)
+
+        dstBuf.put(srcBuf)
+    }
+}

--- a/mediaplayer/src/jvmMain/kotlin/io/github/kdroidfilter/composemediaplayer/windows/WindowsFrameUtils.kt
+++ b/mediaplayer/src/jvmMain/kotlin/io/github/kdroidfilter/composemediaplayer/windows/WindowsFrameUtils.kt
@@ -1,0 +1,90 @@
+package io.github.kdroidfilter.composemediaplayer.windows
+
+import java.nio.ByteBuffer
+
+/**
+ * Calculates a fast hash of the frame buffer to detect frame changes.
+ * Samples approximately 200 pixels evenly distributed across the frame.
+ *
+ * @param buffer The source buffer containing BGRA pixel data
+ * @param pixelCount Total number of pixels in the frame
+ * @return A hash value representing the frame content
+ */
+internal fun calculateFrameHash(buffer: ByteBuffer, pixelCount: Int): Int {
+    if (pixelCount <= 0) return 0
+
+    var hash = 1
+    val step = if (pixelCount <= 200) 1 else pixelCount / 200
+    for (i in 0 until pixelCount step step) {
+        hash = 31 * hash + buffer.getInt(i * 4)
+    }
+    return hash
+}
+
+/**
+ * Copies BGRA frame data from source to destination buffer with minimal overhead.
+ * Handles row padding when destination stride differs from source.
+ *
+ * This function performs a single memory copy operation when strides match,
+ * achieving zero-copy performance (beyond the necessary single copy from
+ * native buffer to Skia bitmap).
+ *
+ * @param src Source buffer containing BGRA pixel data from Media Foundation
+ * @param dst Destination buffer (Skia bitmap pixels via peekPixels)
+ * @param width Frame width in pixels
+ * @param height Frame height in pixels
+ * @param dstRowBytes Destination row stride (may include padding)
+ */
+internal fun copyBgraFrame(
+    src: ByteBuffer,
+    dst: ByteBuffer,
+    width: Int,
+    height: Int,
+    dstRowBytes: Int,
+) {
+    require(width > 0) { "width must be > 0 (was $width)" }
+    require(height > 0) { "height must be > 0 (was $height)" }
+    val srcRowBytes = width * 4
+    require(dstRowBytes >= srcRowBytes) {
+        "dstRowBytes ($dstRowBytes) must be >= srcRowBytes ($srcRowBytes)"
+    }
+
+    val requiredSrcBytes = srcRowBytes.toLong() * height.toLong()
+    val requiredDstBytes = dstRowBytes.toLong() * height.toLong()
+    require(src.capacity().toLong() >= requiredSrcBytes) {
+        "src buffer too small: ${src.capacity()} < $requiredSrcBytes"
+    }
+    require(dst.capacity().toLong() >= requiredDstBytes) {
+        "dst buffer too small: ${dst.capacity()} < $requiredDstBytes"
+    }
+
+    val srcBuf = src.duplicate()
+    val dstBuf = dst.duplicate()
+    srcBuf.rewind()
+    dstBuf.rewind()
+
+    // Fast path: when strides match, do a single bulk copy
+    if (dstRowBytes == srcRowBytes) {
+        srcBuf.limit(requiredSrcBytes.toInt())
+        dstBuf.limit(requiredSrcBytes.toInt())
+        dstBuf.put(srcBuf)
+        return
+    }
+
+    // Slow path: copy row by row when there's padding
+    val srcCapacity = srcBuf.capacity()
+    val dstCapacity = dstBuf.capacity()
+    for (row in 0 until height) {
+        val srcPos = row * srcRowBytes
+        srcBuf.limit(srcCapacity)
+        srcBuf.position(srcPos)
+        srcBuf.limit(srcPos + srcRowBytes)
+
+        val dstPos = row * dstRowBytes
+        dstBuf.limit(dstCapacity)
+        dstBuf.position(dstPos)
+        dstBuf.limit(dstPos + srcRowBytes)
+
+        dstBuf.put(srcBuf)
+    }
+}

--- a/mediaplayer/src/jvmMain/kotlin/io/github/kdroidfilter/composemediaplayer/windows/WindowsVideoPlayerState.kt
+++ b/mediaplayer/src/jvmMain/kotlin/io/github/kdroidfilter/composemediaplayer/windows/WindowsVideoPlayerState.kt
@@ -355,7 +355,14 @@ class WindowsVideoPlayerState : PlatformVideoPlayerState {
 
         // Free bitmaps and frame buffers
         bitmapLock.write {
-            _currentFrame?.close()
+            val currentFrame = _currentFrame
+            if (currentFrame != null &&
+                currentFrame !== skiaBitmapA &&
+                currentFrame !== skiaBitmapB &&
+                currentFrame !== frameBitmapRecycler
+            ) {
+                currentFrame.close()
+            }
             _currentFrame = null
             currentFrameState.value = null
             frameBitmapRecycler?.close()
@@ -404,7 +411,14 @@ class WindowsVideoPlayerState : PlatformVideoPlayerState {
 
         // Free bitmaps and frame buffers
         bitmapLock.write {
-            _currentFrame?.close()  // Close the current frame bitmap if any
+            val currentFrame = _currentFrame
+            if (currentFrame != null &&
+                currentFrame !== skiaBitmapA &&
+                currentFrame !== skiaBitmapB &&
+                currentFrame !== frameBitmapRecycler
+            ) {
+                currentFrame.close()
+            }
             _currentFrame = null
             // Reset the currentFrameState
             currentFrameState.value = null

--- a/mediaplayer/src/jvmTest/kotlin/io/github/kdroidfilter/composemediaplayer/mac/MacFrameUtilsTest.kt
+++ b/mediaplayer/src/jvmTest/kotlin/io/github/kdroidfilter/composemediaplayer/mac/MacFrameUtilsTest.kt
@@ -1,0 +1,113 @@
+package io.github.kdroidfilter.composemediaplayer.mac
+
+import java.nio.ByteBuffer
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNotEquals
+
+class MacFrameUtilsTest {
+    @Test
+    fun calculateFrameHash_returnsZeroWhenEmpty() {
+        assertEquals(0, calculateFrameHash(ByteBuffer.allocate(0), 0))
+        assertEquals(0, calculateFrameHash(ByteBuffer.allocate(0), -1))
+    }
+
+    @Test
+    fun calculateFrameHash_changesWhenSampledPixelChanges() {
+        val pixelCount = 1000
+        val buf = ByteBuffer.allocate(pixelCount * 4)
+        for (i in 0 until pixelCount) {
+            buf.putInt(i * 4, i)
+        }
+
+        val hash1 = calculateFrameHash(buf, pixelCount)
+
+        // With pixelCount=1000, step=5 => index 5 is sampled.
+        buf.putInt(5 * 4, 123456)
+        val hash2 = calculateFrameHash(buf, pixelCount)
+
+        assertNotEquals(hash1, hash2)
+    }
+
+    @Test
+    fun copyBgraFrame_copiesContiguousRows() {
+        val width = 2
+        val height = 2
+        val rowBytes = width * 4
+        val size = rowBytes * height
+
+        val src = ByteBuffer.allocate(size)
+        for (i in 0 until size) {
+            src.put(i, i.toByte())
+        }
+        val dst = ByteBuffer.allocate(size)
+
+        copyBgraFrame(src, dst, width, height, rowBytes)
+
+        for (i in 0 until size) {
+            assertEquals(src.get(i), dst.get(i), "Mismatch at byte index $i")
+        }
+    }
+
+    @Test
+    fun copyBgraFrame_copiesWithRowPadding() {
+        val width = 2
+        val height = 2
+        val srcRowBytes = width * 4
+        val dstRowBytes = srcRowBytes + 4
+
+        val srcSize = srcRowBytes * height
+        val dstSize = dstRowBytes * height
+
+        val src = ByteBuffer.allocate(srcSize)
+        for (i in 0 until srcSize) {
+            src.put(i, (i + 1).toByte())
+        }
+
+        val dst = ByteBuffer.allocate(dstSize)
+        val paddingSentinel = 0x7F.toByte()
+        for (i in 0 until dstSize) {
+            dst.put(i, paddingSentinel)
+        }
+
+        copyBgraFrame(src, dst, width, height, dstRowBytes)
+
+        for (row in 0 until height) {
+            val srcBase = row * srcRowBytes
+            val dstBase = row * dstRowBytes
+
+            for (i in 0 until srcRowBytes) {
+                assertEquals(
+                    src.get(srcBase + i),
+                    dst.get(dstBase + i),
+                    "Row $row mismatch at byte index $i",
+                )
+            }
+
+            for (i in srcRowBytes until dstRowBytes) {
+                assertEquals(
+                    paddingSentinel,
+                    dst.get(dstBase + i),
+                    "Row $row padding byte $i should be untouched",
+                )
+            }
+        }
+    }
+
+    @Test
+    fun copyBgraFrame_requiresValidRowBytes() {
+        val width = 2
+        val height = 1
+        val srcRowBytes = width * 4
+        val dstRowBytes = srcRowBytes - 1
+
+        val src = ByteBuffer.allocate(srcRowBytes * height)
+        val dst = ByteBuffer.allocate(dstRowBytes * height)
+
+        assertFailsWith<IllegalArgumentException> {
+            copyBgraFrame(src, dst, width, height, dstRowBytes)
+        }
+    }
+}
+


### PR DESCRIPTION
Refines the bitmap cleanup logic in `WindowsVideoPlayerState` to prevent unintended disposal of shared frames. Introduces platform-specific utilities to handle frame operations and optimizes frame processing in `VideoPlayerState`.
Fix #140 