### PR TITLE
fix: loop no smooth on Ios player

### DIFF
--- a/mediaplayer/src/iosMain/kotlin/io/github/kdroidfilter/composemediaplayer/VideoPlayerState.ios.kt
+++ b/mediaplayer/src/iosMain/kotlin/io/github/kdroidfilter/composemediaplayer/VideoPlayerState.ios.kt
@@ -252,8 +252,18 @@ open class DefaultVideoPlayerState: VideoPlayerState {
             queue = null
         ) { _ ->
             if (_loop) {
-                player.seekToTime(CMTimeMakeWithSeconds(0.0, 1))
-                player.playImmediatelyAtRate(_playbackSpeed)
+                val zeroTime = CMTimeMake(0, 1)
+                player.seekToTime(
+                    time = CMTimeMakeWithSeconds(0.0, NSEC_PER_SEC.toInt()),
+                    toleranceBefore = zeroTime,
+                    toleranceAfter = zeroTime
+                ) { finished ->
+                    if (finished) {
+                        dispatch_async(dispatch_get_main_queue()) {
+                            player.playImmediatelyAtRate(_playbackSpeed)
+                        }
+                    }
+                }
             } else {
                 player.pause()
                 _isPlaying = false


### PR DESCRIPTION
## Summary
- Fix the noticeable delay when video loops on iOS by using precise seeking with completion handler
- The seek operation now waits for completion before resuming playback
- Playback resumes on the main thread for thread safety

## Changes
- Use `seekToTime` with zero tolerance (`toleranceBefore` and `toleranceAfter`) for precise seeking
- Wait for seek completion via callback before calling `playImmediatelyAtRate`
- Dispatch playback resume to main queue

## Test plan
- [x] Play a short video with loop enabled on iOS
- [x] Observe the loop point - should be seamless without visible delay
- [x] Test with different video lengths
- [x] Test remote and local videos

Fixes #126