### PR TITLE
Fix currentTime and sliderPos not reaching end of media

### DIFF
--- a/mediaplayer/src/jvmMain/kotlin/io/github/kdroidfilter/composemediaplayer/windows/WindowsVideoPlayerState.kt
+++ b/mediaplayer/src/jvmMain/kotlin/io/github/kdroidfilter/composemediaplayer/windows/WindowsVideoPlayerState.kt
@@ -703,6 +703,13 @@ class WindowsVideoPlayerState : VideoPlayerState {
                         setError("Error during SeekMedia for loop: ${e.message}")
                     }
                 } else {
+                    // The last decoded frame's timestamp is always slightly before the
+                    // total duration (duration = last_frame_pts + frame_duration), so
+                    // snap currentTime/progress to the end when playback completes.
+                    if (_duration > 0.0) {
+                        _currentTime = _duration
+                        _progress = 1f
+                    }
                     pause()
                     break
                 }


### PR DESCRIPTION
## Summary
- Snap `currentTime` to duration and `progress` to 1.0 when EOF is reached, so `sliderPos` correctly reaches 1000
- The last decoded frame's PTS is always slightly before the total duration (duration = last_frame_pts + frame_duration), which is normal behavior for all video decoders

Fixes #138

## Test plan
- [ ] Play a video to completion and verify `currentTime` matches the duration
- [ ] Verify `sliderPos` reaches 1000 at the end of playback
- [ ] Verify looping still works correctly (no regression)