### PR TITLE
[Logging] Make the explicit loggers local

### DIFF
--- a/mediaplayer/src/androidMain/kotlin/io/github/kdroidfilter/composemediaplayer/VideoPlayerState.android.kt
+++ b/mediaplayer/src/androidMain/kotlin/io/github/kdroidfilter/composemediaplayer/VideoPlayerState.android.kt
@@ -26,9 +26,8 @@ import androidx.media3.exoplayer.audio.DefaultAudioSink
 import androidx.media3.exoplayer.mediacodec.MediaCodecSelector
 import androidx.media3.ui.CaptionStyleCompat
 import androidx.media3.ui.PlayerView
-import co.touchlab.kermit.Logger
-import co.touchlab.kermit.Severity
 import com.kdroid.androidcontextprovider.ContextProvider
+import io.github.kdroidfilter.composemediaplayer.util.buildLocalLogger
 import io.github.kdroidfilter.composemediaplayer.util.formatTime
 import io.github.vinceglb.filekit.AndroidFile
 import io.github.vinceglb.filekit.PlatformFile
@@ -70,8 +69,7 @@ actual fun createVideoPlayerState(): VideoPlayerState =
 /**
  * Logger for WebAssembly video player surface
  */
-internal val androidVideoLogger = Logger.withTag("AndroidVideoPlayerSurface")
-    .apply { Logger.setMinSeverity(Severity.Warn) }
+internal val androidVideoLogger = buildLocalLogger("AndroidVideoPlayerSurface")
 
 @UnstableApi
 @Stable

--- a/mediaplayer/src/commonMain/kotlin/io/github/kdroidfilter/composemediaplayer/util/Logger.kt
+++ b/mediaplayer/src/commonMain/kotlin/io/github/kdroidfilter/composemediaplayer/util/Logger.kt
@@ -1,0 +1,12 @@
+package io.github.kdroidfilter.composemediaplayer.util
+
+import co.touchlab.kermit.Logger
+import co.touchlab.kermit.Severity
+import co.touchlab.kermit.mutableLoggerConfigInit
+import co.touchlab.kermit.platformLogWriter
+
+fun buildLocalLogger(tag: String, minSeverity: Severity = Severity.Warn) =
+    Logger(mutableLoggerConfigInit(listOf(platformLogWriter())), tag)
+        .apply {
+            mutableConfig.minSeverity = minSeverity
+        }

--- a/mediaplayer/src/jvmMain/kotlin/io/github/kdroidfilter/composemediaplayer/mac/MacVideoPlayerState.kt
+++ b/mediaplayer/src/jvmMain/kotlin/io/github/kdroidfilter/composemediaplayer/mac/MacVideoPlayerState.kt
@@ -8,15 +8,13 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.sp
-import co.touchlab.kermit.Logger
-import co.touchlab.kermit.Logger.Companion.setMinSeverity
-import co.touchlab.kermit.Severity
 import com.sun.jna.Pointer
 import io.github.kdroidfilter.composemediaplayer.InitialPlayerState
 import io.github.kdroidfilter.composemediaplayer.VideoPlayerState
 import io.github.kdroidfilter.composemediaplayer.SubtitleTrack
 import io.github.kdroidfilter.composemediaplayer.VideoMetadata
 import io.github.kdroidfilter.composemediaplayer.VideoPlayerError
+import io.github.kdroidfilter.composemediaplayer.util.buildLocalLogger
 import io.github.kdroidfilter.composemediaplayer.util.formatTime
 import io.github.vinceglb.filekit.PlatformFile
 import io.github.vinceglb.filekit.utils.toFile
@@ -35,9 +33,7 @@ import kotlin.math.abs
 import kotlin.math.log10
 
 // Initialize logger using Kermit
-internal val macLogger = Logger.withTag("MacVideoPlayerState")
-    .apply { setMinSeverity(Severity.Warn) }
-
+internal val macLogger = buildLocalLogger("MacVideoPlayerState")
 /**
  * MacVideoPlayerState handles the native Mac video player state.
  *

--- a/mediaplayer/src/jvmMain/kotlin/io/github/kdroidfilter/composemediaplayer/windows/WindowsVideoPlayerState.kt
+++ b/mediaplayer/src/jvmMain/kotlin/io/github/kdroidfilter/composemediaplayer/windows/WindowsVideoPlayerState.kt
@@ -11,14 +11,12 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.sp
-import co.touchlab.kermit.Logger
-import co.touchlab.kermit.Logger.Companion.setMinSeverity
-import co.touchlab.kermit.Severity
 import io.github.kdroidfilter.composemediaplayer.InitialPlayerState
 import io.github.kdroidfilter.composemediaplayer.SubtitleTrack
 import io.github.kdroidfilter.composemediaplayer.VideoMetadata
 import io.github.kdroidfilter.composemediaplayer.VideoPlayerError
 import io.github.kdroidfilter.composemediaplayer.VideoPlayerState
+import io.github.kdroidfilter.composemediaplayer.util.buildLocalLogger
 import io.github.kdroidfilter.composemediaplayer.util.formatTime
 import io.github.vinceglb.filekit.PlatformFile
 import kotlinx.coroutines.CancellationException
@@ -58,8 +56,7 @@ import kotlin.math.min
 /**
  * Logger for Windows video player implementation
  */
-internal val windowsLogger = Logger.withTag("WindowsVideoPlayerState")
-    .apply { setMinSeverity(Severity.Warn) }
+internal val windowsLogger = buildLocalLogger("WindowsVideoPlayerState")
 
 /**
  * Windows implementation of the video player state.

--- a/mediaplayer/src/webMain/kotlin/io/github/kdroidfilter/composemediaplayer/AudioLevelProcessor.kt
+++ b/mediaplayer/src/webMain/kotlin/io/github/kdroidfilter/composemediaplayer/AudioLevelProcessor.kt
@@ -1,11 +1,10 @@
 package io.github.kdroidfilter.composemediaplayer
 
-import co.touchlab.kermit.Logger
-import co.touchlab.kermit.Severity
 import io.github.kdroidfilter.composemediaplayer.jsinterop.AnalyserNode
 import io.github.kdroidfilter.composemediaplayer.jsinterop.AudioContext
 import io.github.kdroidfilter.composemediaplayer.jsinterop.ChannelSplitterNode
 import io.github.kdroidfilter.composemediaplayer.jsinterop.MediaElementAudioSourceNode
+import io.github.kdroidfilter.composemediaplayer.util.buildLocalLogger
 import org.khronos.webgl.Uint8Array
 import org.khronos.webgl.get
 import org.w3c.dom.HTMLVideoElement
@@ -13,8 +12,7 @@ import org.w3c.dom.HTMLVideoElement
 /**
  * Logger for WebAssembly audio level processor
  */
-internal val wasmAudioLogger = Logger.withTag("WasmAudioProcessor")
-    .apply { Logger.setMinSeverity(Severity.Warn) }
+internal val wasmAudioLogger = buildLocalLogger("WasmAudioProcessor")
 
 internal class AudioLevelProcessor(private val video: HTMLVideoElement) {
 

--- a/mediaplayer/src/webMain/kotlin/io/github/kdroidfilter/composemediaplayer/VideoPlayerSurfaceImpl.kt
+++ b/mediaplayer/src/webMain/kotlin/io/github/kdroidfilter/composemediaplayer/VideoPlayerSurfaceImpl.kt
@@ -13,11 +13,10 @@ import androidx.compose.ui.graphics.BlendMode
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.layout.ContentScale
-import co.touchlab.kermit.Logger
-import co.touchlab.kermit.Severity
 import io.github.kdroidfilter.composemediaplayer.jsinterop.MediaError
 import io.github.kdroidfilter.composemediaplayer.subtitle.ComposeSubtitleLayer
 import io.github.kdroidfilter.composemediaplayer.util.FullScreenLayout
+import io.github.kdroidfilter.composemediaplayer.util.buildLocalLogger
 import io.github.kdroidfilter.composemediaplayer.util.toTimeMs
 import kotlinx.browser.document
 import kotlinx.coroutines.CoroutineScope
@@ -29,7 +28,7 @@ import org.w3c.dom.HTMLVideoElement
 import org.w3c.dom.events.Event
 import kotlin.math.abs
 
-internal val webVideoLogger = Logger.withTag("WebVideoPlayerSurface").apply { Logger.setMinSeverity(Severity.Warn) }
+internal val webVideoLogger = buildLocalLogger("WebVideoPlayerSurface")
 
 // Cache mime type mappings for better performance
 internal val EXTENSION_TO_MIME_TYPE = mapOf(

--- a/mediaplayer/src/webMain/kotlin/io/github/kdroidfilter/composemediaplayer/subtitle/SubtitleLoader.web.kt
+++ b/mediaplayer/src/webMain/kotlin/io/github/kdroidfilter/composemediaplayer/subtitle/SubtitleLoader.web.kt
@@ -1,7 +1,6 @@
 package io.github.kdroidfilter.composemediaplayer.subtitle
 
-import co.touchlab.kermit.Logger
-import co.touchlab.kermit.Severity
+import io.github.kdroidfilter.composemediaplayer.util.buildLocalLogger
 import kotlinx.browser.window
 import kotlinx.coroutines.suspendCancellableCoroutine
 import org.w3c.dom.url.URL
@@ -15,9 +14,7 @@ import kotlin.coroutines.resume
  * @param src The source URI of the subtitle file
  * @return The content of the subtitle file as a string
  */
-private val webSubtitleLogger = Logger.withTag("WebSubtitleLoader").apply {
-    Logger.setMinSeverity(Severity.Warn)
-}
+private val webSubtitleLogger = buildLocalLogger("WebSubtitleLoader")
 
 actual suspend fun loadSubtitleContent(src: String): String = suspendCancellableCoroutine { continuation ->
     try {


### PR DESCRIPTION
This commit tries to avoid any side effect on the Kermit logger behaviours for the library client.

This patch is trying to fix this issue: https://github.com/kdroidFilter/ComposeMediaPlayer/issues/169

Please note, this behaviour is pretty invasive and I lost a lot of hours, thinking my app navigation was broken when the log config was actually simply changed as soon as was calling `rememberVideoPlayerState()`


## Patch details

In the previous implementation, several loggers are declared using the Kermit API `Logger.withTag`. Then the `Logger.setMinSeverity` is called to change the minimum severity required to log.

There are 2 potential impacts outside the library here:
- The `Logger.setMinSeverity` is changing the global `Logger.config` which is shared with the client library
- The `Logger.withTag` API is creating a new Logger instance but it is keeping the parent configuration reference, which also refers to the global Logger.config reference shared with the library client.

The solution proposed:
- We create a new independent `Logger` instance
- We configure the instance using the local `mutableConfig.minSeverity` API

## Improvement

- Remove the side effects on the library client
- Keep the logger local, meaning we can change the verbosity of a single element without impacting other elements.

## Other behaviour change

All the logs declared with `Logger.d()` in the `VideoPlayerSurface.ios.kt` file will now be displayed as the global Logger min level is not changed anymore.