### PR TITLE
Lower min playback speed to 0.25x and extract constants

### DIFF
--- a/mediaplayer/src/androidMain/kotlin/io/github/kdroidfilter/composemediaplayer/VideoPlayerState.android.kt
+++ b/mediaplayer/src/androidMain/kotlin/io/github/kdroidfilter/composemediaplayer/VideoPlayerState.android.kt
@@ -215,7 +215,7 @@ open class DefaultVideoPlayerState: VideoPlayerState {
     override var playbackSpeed: Float
         get() = _playbackSpeed
         set(value) {
-            _playbackSpeed = value.coerceIn(0.5f, 2.0f)
+            _playbackSpeed = value.coerceIn(VideoPlayerState.MIN_PLAYBACK_SPEED, VideoPlayerState.MAX_PLAYBACK_SPEED)
             exoPlayer?.let { player ->
                 player.playbackParameters = PlaybackParameters(_playbackSpeed)
             }

--- a/mediaplayer/src/commonMain/kotlin/io/github/kdroidfilter/composemediaplayer/VideoPlayerState.kt
+++ b/mediaplayer/src/commonMain/kotlin/io/github/kdroidfilter/composemediaplayer/VideoPlayerState.kt
@@ -53,6 +53,11 @@ interface VideoPlayerState {
     var loop: Boolean
     var playbackSpeed: Float
 
+    companion object {
+        const val MIN_PLAYBACK_SPEED = 0.25f
+        const val MAX_PLAYBACK_SPEED = 2.0f
+    }
+
     /**
      * Provides the audio level for the left channel as a percentage.
      */

--- a/mediaplayer/src/iosMain/kotlin/io/github/kdroidfilter/composemediaplayer/VideoPlayerState.ios.kt
+++ b/mediaplayer/src/iosMain/kotlin/io/github/kdroidfilter/composemediaplayer/VideoPlayerState.ios.kt
@@ -76,7 +76,7 @@ open class DefaultVideoPlayerState: VideoPlayerState {
     override var playbackSpeed: Float
         get() = _playbackSpeed
         set(value) {
-            _playbackSpeed = value.coerceIn(0.5f, 2.0f)
+            _playbackSpeed = value.coerceIn(VideoPlayerState.MIN_PLAYBACK_SPEED, VideoPlayerState.MAX_PLAYBACK_SPEED)
             // Only update player rate if we are playing to avoid auto-play
             if (_isPlaying) {
                 player?.rate = _playbackSpeed

--- a/mediaplayer/src/jvmMain/kotlin/io/github/kdroidfilter/composemediaplayer/linux/LinuxVideoPlayerState.kt
+++ b/mediaplayer/src/jvmMain/kotlin/io/github/kdroidfilter/composemediaplayer/linux/LinuxVideoPlayerState.kt
@@ -141,7 +141,7 @@ class LinuxVideoPlayerState : VideoPlayerState {
     override var playbackSpeed: Float
         get() = _playbackSpeedState.value
         set(value) {
-            val newValue = value.coerceIn(0.5f, 2.0f)
+            val newValue = value.coerceIn(VideoPlayerState.MIN_PLAYBACK_SPEED, VideoPlayerState.MAX_PLAYBACK_SPEED)
             if (_playbackSpeedState.value != newValue) {
                 _playbackSpeedState.value = newValue
                 ioScope.launch { applyPlaybackSpeed() }

--- a/mediaplayer/src/jvmMain/kotlin/io/github/kdroidfilter/composemediaplayer/mac/MacVideoPlayerState.kt
+++ b/mediaplayer/src/jvmMain/kotlin/io/github/kdroidfilter/composemediaplayer/mac/MacVideoPlayerState.kt
@@ -147,7 +147,7 @@ class MacVideoPlayerState : VideoPlayerState {
     override var playbackSpeed: Float
         get() = _playbackSpeedState.value
         set(value) {
-            val newValue = value.coerceIn(0.5f, 2.0f)
+            val newValue = value.coerceIn(VideoPlayerState.MIN_PLAYBACK_SPEED, VideoPlayerState.MAX_PLAYBACK_SPEED)
             if (_playbackSpeedState.value != newValue) {
                 _playbackSpeedState.value = newValue
                 // Launch a coroutine to apply the playback speed if the native player is available.

--- a/mediaplayer/src/jvmMain/kotlin/io/github/kdroidfilter/composemediaplayer/windows/WindowsVideoPlayerState.kt
+++ b/mediaplayer/src/jvmMain/kotlin/io/github/kdroidfilter/composemediaplayer/windows/WindowsVideoPlayerState.kt
@@ -169,7 +169,7 @@ class WindowsVideoPlayerState : VideoPlayerState {
     override var playbackSpeed: Float
         get() = _playbackSpeed
         set(value) {
-            val newSpeed = value.coerceIn(0.5f, 2.0f)
+            val newSpeed = value.coerceIn(VideoPlayerState.MIN_PLAYBACK_SPEED, VideoPlayerState.MAX_PLAYBACK_SPEED)
             if (_playbackSpeed != newSpeed) {
                 _playbackSpeed = newSpeed
                 scope.launch {

--- a/mediaplayer/src/webMain/kotlin/io/github/kdroidfilter/composemediaplayer/VideoPlayerState.web.kt
+++ b/mediaplayer/src/webMain/kotlin/io/github/kdroidfilter/composemediaplayer/VideoPlayerState.web.kt
@@ -104,7 +104,7 @@ open class DefaultVideoPlayerState: VideoPlayerState {
     override var playbackSpeed: Float
         get() = _playbackSpeed
         set(value) {
-            val newValue = value.coerceIn(0.5f, 2.0f)
+            val newValue = value.coerceIn(VideoPlayerState.MIN_PLAYBACK_SPEED, VideoPlayerState.MAX_PLAYBACK_SPEED)
             if (_playbackSpeed != newValue) {
                 _playbackSpeed = newValue
                 applyPlaybackSpeedWithThrottle(newValue)


### PR DESCRIPTION
## Summary
- Lower minimum playback speed from `0.5x` to `0.25x` as requested in #110
- Extract `MIN_PLAYBACK_SPEED` / `MAX_PLAYBACK_SPEED` constants into `VideoPlayerState.Companion` to eliminate duplicated magic numbers across all 6 platform implementations (Android, iOS, Linux, Mac, Windows, Web)

## Test plan
- [ ] Verify playback speed can be set to 0.25x on each platform
- [ ] Verify playback speed is still clamped at 2.0x max
- [ ] Verify normal playback (1.0x) is unaffected

Closes #110