### PR TITLE
fix(android): remove default ExoPlayer buffering spinner

### DIFF
--- a/mediaplayer/src/androidMain/res/layout/player_view_surface.xml
+++ b/mediaplayer/src/androidMain/res/layout/player_view_surface.xml
@@ -5,5 +5,5 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         app:surface_type="surface_view"
-        app:show_buffering="when_playing"
+        app:show_buffering="never"
         app:use_controller="false" />

--- a/mediaplayer/src/androidMain/res/layout/player_view_texture.xml
+++ b/mediaplayer/src/androidMain/res/layout/player_view_texture.xml
@@ -5,5 +5,5 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         app:surface_type="texture_view"
-        app:show_buffering="when_playing"
+        app:show_buffering="never"
         app:use_controller="false" />


### PR DESCRIPTION
## Summary
- Set `app:show_buffering="never"` in both `player_view_texture.xml` and `player_view_surface.xml` to disable ExoPlayer's default green circular buffering indicator
- The `isLoading` state remains available on `VideoPlayerState` so consumers can provide their own custom loading UI via the overlay composable

Closes #142

## Test plan
- [x] Play a video on Android and verify the green buffering spinner no longer appears
- [x] Verify buffering still works correctly (video resumes after buffering)
- [x] Confirm `playerState.isLoading` still reflects buffering state for custom UI