### PR TITLE
fix(mac,linux): convert VideoMetadata.duration to milliseconds

### DIFF
--- a/mediaplayer/src/jvmMain/kotlin/io/github/kdroidfilter/composemediaplayer/linux/LinuxVideoPlayerState.kt
+++ b/mediaplayer/src/jvmMain/kotlin/io/github/kdroidfilter/composemediaplayer/linux/LinuxVideoPlayerState.kt
@@ -379,7 +379,7 @@ class LinuxVideoPlayerState : VideoPlayerState {
         try {
             val width = LinuxNativeBridge.nGetFrameWidth(ptr)
             val height = LinuxNativeBridge.nGetFrameHeight(ptr)
-            val duration = LinuxNativeBridge.nGetVideoDuration(ptr).toLong()
+            val duration = (LinuxNativeBridge.nGetVideoDuration(ptr) * 1000).toLong()
             val frameRate = LinuxNativeBridge.nGetFrameRate(ptr)
             val newAspectRatio =
                 if (width > 0 && height > 0) {

--- a/mediaplayer/src/jvmMain/kotlin/io/github/kdroidfilter/composemediaplayer/mac/MacVideoPlayerState.kt
+++ b/mediaplayer/src/jvmMain/kotlin/io/github/kdroidfilter/composemediaplayer/mac/MacVideoPlayerState.kt
@@ -448,7 +448,7 @@ class MacVideoPlayerState : VideoPlayerState {
         try {
             val width = MacNativeBridge.nGetFrameWidth(ptr)
             val height = MacNativeBridge.nGetFrameHeight(ptr)
-            val duration = MacNativeBridge.nGetVideoDuration(ptr).toLong()
+            val duration = (MacNativeBridge.nGetVideoDuration(ptr) * 1000).toLong()
             val frameRate = MacNativeBridge.nGetVideoFrameRate(ptr)
 
             // Calculate aspect ratio


### PR DESCRIPTION
## Summary

- `nGetVideoDuration()` returns seconds on macOS (`CMTimeGetSeconds`) and Linux (`gst_duration / GST_SECOND`)
- `metadata.duration` was assigned directly without converting to milliseconds, causing a unit mismatch with the documented API contract
- Multiply by 1000 before assigning to align with iOS, Android, Windows, and Web platforms

Fixes #153

## Test plan

- [x] Verify `VideoMetadata.duration` returns milliseconds on macOS
- [x] Verify `VideoMetadata.duration` returns milliseconds on Linux
- [x] Confirm seek and progress bar behavior is correct on both platforms
- [x] Verify no regression on other platforms (iOS, Android, Windows, Web)