### PR TITLE
feat: add onPlaybackEnded callback to VideoPlayerState

### DIFF
--- a/mediaplayer/src/androidMain/kotlin/io/github/kdroidfilter/composemediaplayer/VideoPlayerState.android.kt
+++ b/mediaplayer/src/androidMain/kotlin/io/github/kdroidfilter/composemediaplayer/VideoPlayerState.android.kt
@@ -225,6 +225,8 @@ open class DefaultVideoPlayerState(
     // User interaction states
     override var userDragging by mutableStateOf(false)
 
+    override var onPlaybackEnded: (() -> Unit)? = null
+
     // Loop control
     private var _loop by mutableStateOf(false)
     override var loop: Boolean
@@ -454,6 +456,7 @@ open class DefaultVideoPlayerState(
                         _isLoading = false
                         stopPositionUpdates()
                         _isPlaying = false
+                        onPlaybackEnded?.invoke()
                     }
 
                     Player.STATE_IDLE -> {

--- a/mediaplayer/src/commonMain/kotlin/io/github/kdroidfilter/composemediaplayer/VideoPlayerState.kt
+++ b/mediaplayer/src/commonMain/kotlin/io/github/kdroidfilter/composemediaplayer/VideoPlayerState.kt
@@ -37,7 +37,7 @@ interface VideoPlayerState {
     var volume: Float
 
     /**
-     * Represents the current playback position as a normalized value between 0.0 and 1.0.
+     * Represents the current playback position as a value between 0.0 and 1000.0.
      */
     var sliderPos: Float
 
@@ -51,6 +51,12 @@ interface VideoPlayerState {
      */
     var loop: Boolean
     var playbackSpeed: Float
+
+    /**
+     * Callback invoked when playback reaches the end of the media.
+     * Only called when [loop] is false. May be invoked from a background thread.
+     */
+    var onPlaybackEnded: (() -> Unit)?
 
     companion object {
         const val MIN_PLAYBACK_SPEED = 0.25f
@@ -96,7 +102,7 @@ interface VideoPlayerState {
     fun stop()
 
     /**
-     * Seeks to a specific playback position based on the provided normalized value.
+     * Seeks to a specific playback position. The [value] should be between 0.0 and 1000.0.
      */
     fun seekTo(value: Float)
 
@@ -196,6 +202,7 @@ data class PreviewableVideoPlayerState(
     override val isPipSupported: Boolean = false,
     override var isPipActive: Boolean = false,
     override var isPipEnabled: Boolean = false,
+    override var onPlaybackEnded: (() -> Unit)? = null,
 ) : VideoPlayerState {
     override fun play() {}
 

--- a/mediaplayer/src/iosMain/kotlin/io/github/kdroidfilter/composemediaplayer/VideoPlayerState.ios.kt
+++ b/mediaplayer/src/iosMain/kotlin/io/github/kdroidfilter/composemediaplayer/VideoPlayerState.ios.kt
@@ -72,6 +72,7 @@ open class DefaultVideoPlayerState(
             }
         }
 
+    override var onPlaybackEnded: (() -> Unit)? = null
     override var sliderPos: Float by mutableStateOf(0f) // value between 0 and 1000
     override var userDragging: Boolean = false
     private var _loop by mutableStateOf(false)
@@ -344,6 +345,7 @@ open class DefaultVideoPlayerState(
                 } else {
                     player.pause()
                     _isPlaying = false
+                    onPlaybackEnded?.invoke()
                 }
             }
 

--- a/mediaplayer/src/jvmMain/kotlin/io/github/kdroidfilter/composemediaplayer/VideoPlayerState.jvm.kt
+++ b/mediaplayer/src/jvmMain/kotlin/io/github/kdroidfilter/composemediaplayer/VideoPlayerState.jvm.kt
@@ -126,5 +126,11 @@ open class DefaultVideoPlayerState : VideoPlayerState {
 
     override fun dispose() = delegate.dispose()
 
+    override var onPlaybackEnded: (() -> Unit)?
+        get() = delegate.onPlaybackEnded
+        set(value) {
+            delegate.onPlaybackEnded = value
+        }
+
     override fun clearError() = delegate.clearError()
 }

--- a/mediaplayer/src/jvmMain/kotlin/io/github/kdroidfilter/composemediaplayer/linux/LinuxVideoPlayerState.kt
+++ b/mediaplayer/src/jvmMain/kotlin/io/github/kdroidfilter/composemediaplayer/linux/LinuxVideoPlayerState.kt
@@ -82,6 +82,7 @@ class LinuxVideoPlayerState : VideoPlayerState {
     override var userDragging: Boolean by mutableStateOf(false)
     override var loop: Boolean by mutableStateOf(false)
     override var isLoading: Boolean by mutableStateOf(false)
+    override var onPlaybackEnded: (() -> Unit)? = null
     override var error: VideoPlayerError? by mutableStateOf(null)
     override var subtitlesEnabled: Boolean by mutableStateOf(false)
     override var currentSubtitleTrack: SubtitleTrack? by mutableStateOf(null)
@@ -572,6 +573,7 @@ class LinuxVideoPlayerState : VideoPlayerState {
         } else {
             withContext(Dispatchers.Main) { isPlaying = false }
             pauseInBackground()
+            onPlaybackEnded?.invoke()
         }
     }
 

--- a/mediaplayer/src/jvmMain/kotlin/io/github/kdroidfilter/composemediaplayer/linux/LinuxVideoPlayerState.kt
+++ b/mediaplayer/src/jvmMain/kotlin/io/github/kdroidfilter/composemediaplayer/linux/LinuxVideoPlayerState.kt
@@ -505,7 +505,7 @@ class LinuxVideoPlayerState : VideoPlayerState {
 
                     // Native-to-native copy: frame buffer -> Skia bitmap pixels
                     srcBuf.rewind()
-                    val destRowBytes = pixmap.rowBytes.toInt()
+                    val destRowBytes = pixmap.rowBytes
                     val destSizeBytes = destRowBytes.toLong() * height.toLong()
                     val destBuf =
                         LinuxNativeBridge.nWrapPointer(pixelsAddr, destSizeBytes)

--- a/mediaplayer/src/jvmMain/kotlin/io/github/kdroidfilter/composemediaplayer/mac/MacVideoPlayerState.kt
+++ b/mediaplayer/src/jvmMain/kotlin/io/github/kdroidfilter/composemediaplayer/mac/MacVideoPlayerState.kt
@@ -79,6 +79,7 @@ class MacVideoPlayerState : VideoPlayerState {
     override var userDragging: Boolean by mutableStateOf(false)
     override var loop: Boolean by mutableStateOf(false)
     override var isLoading: Boolean by mutableStateOf(false)
+    override var onPlaybackEnded: (() -> Unit)? = null
     override var error: VideoPlayerError? by mutableStateOf(null)
     override var subtitlesEnabled: Boolean by mutableStateOf(false)
     override var currentSubtitleTrack: SubtitleTrack? by mutableStateOf(null)
@@ -699,6 +700,7 @@ class MacVideoPlayerState : VideoPlayerState {
                 isPlaying = false
             }
             pauseInBackground()
+            onPlaybackEnded?.invoke()
         }
     }
 

--- a/mediaplayer/src/jvmMain/kotlin/io/github/kdroidfilter/composemediaplayer/mac/MacVideoPlayerState.kt
+++ b/mediaplayer/src/jvmMain/kotlin/io/github/kdroidfilter/composemediaplayer/mac/MacVideoPlayerState.kt
@@ -605,7 +605,7 @@ class MacVideoPlayerState : VideoPlayerState {
 
                         // Single copy: CVPixelBuffer → Skia bitmap pixels (no intermediate buffer)
                         srcBuf.rewind()
-                        val dstRowBytes = pixmap.rowBytes.toInt()
+                        val dstRowBytes = pixmap.rowBytes
                         val dstSizeBytes = dstRowBytes.toLong() * height.toLong()
                         val destBuf =
                             MacNativeBridge.nWrapPointer(pixelsAddr, dstSizeBytes)

--- a/mediaplayer/src/jvmMain/kotlin/io/github/kdroidfilter/composemediaplayer/util/Uri.kt
+++ b/mediaplayer/src/jvmMain/kotlin/io/github/kdroidfilter/composemediaplayer/util/Uri.kt
@@ -3,4 +3,4 @@ package io.github.kdroidfilter.composemediaplayer.util
 import io.github.vinceglb.filekit.PlatformFile
 import io.github.vinceglb.filekit.path
 
-actual fun PlatformFile.getUri(): String = this.path.toString()
+actual fun PlatformFile.getUri(): String = this.path

--- a/mediaplayer/src/jvmMain/kotlin/io/github/kdroidfilter/composemediaplayer/windows/WindowsVideoPlayerState.kt
+++ b/mediaplayer/src/jvmMain/kotlin/io/github/kdroidfilter/composemediaplayer/windows/WindowsVideoPlayerState.kt
@@ -35,7 +35,6 @@ import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
@@ -160,6 +159,8 @@ class WindowsVideoPlayerState : VideoPlayerState {
         set(value) {
             _loop = value
         }
+
+    override var onPlaybackEnded: (() -> Unit)? = null
 
     private var _playbackSpeed by mutableStateOf(1.0f)
     override var playbackSpeed: Float
@@ -675,6 +676,7 @@ class WindowsVideoPlayerState : VideoPlayerState {
                         _progress = 1f
                     }
                     pause()
+                    onPlaybackEnded?.invoke()
                     break
                 }
             }

--- a/mediaplayer/src/webMain/kotlin/io/github/kdroidfilter/composemediaplayer/VideoPlayerState.web.kt
+++ b/mediaplayer/src/webMain/kotlin/io/github/kdroidfilter/composemediaplayer/VideoPlayerState.web.kt
@@ -62,6 +62,8 @@ open class DefaultVideoPlayerState : VideoPlayerState {
     override val isLoading: Boolean get() = _isLoading
 
     // Error handling
+    override var onPlaybackEnded: (() -> Unit)? = null
+
     private var _error by mutableStateOf<VideoPlayerError?>(null)
     override val error: VideoPlayerError? get() = _error
 

--- a/mediaplayer/src/webMain/kotlin/io/github/kdroidfilter/composemediaplayer/VideoPlayerSurfaceImpl.kt
+++ b/mediaplayer/src/webMain/kotlin/io/github/kdroidfilter/composemediaplayer/VideoPlayerSurfaceImpl.kt
@@ -378,7 +378,12 @@ internal fun setupVideoElement(
             events =
                 mapOf(
                     "timeupdate" to { event -> playerState.onTimeUpdateEvent(event) },
-                    "ended" to { scope.launch { playerState.pause() } },
+                    "ended" to {
+                        scope.launch {
+                            playerState.pause()
+                            playerState.onPlaybackEnded?.invoke()
+                        }
+                    },
                 ),
             loadingEvents =
                 mapOf(

--- a/sample/composeApp/src/commonMain/kotlin/sample/app/player/PlayerScreen.kt
+++ b/sample/composeApp/src/commonMain/kotlin/sample/app/player/PlayerScreen.kt
@@ -102,6 +102,11 @@ fun PlayerScreen(modifier: Modifier = Modifier) {
         }
     }
 
+    // Example: detect when playback reaches the end
+    playerState.onPlaybackEnded = {
+        println("Playback ended")
+    }
+
     // Auto-hide controls when playing
     LaunchedEffect(controlsVisible, playerState.isPlaying) {
         if (controlsVisible && playerState.isPlaying) {


### PR DESCRIPTION
## Summary
- Add `onPlaybackEnded: (() -> Unit)?` callback property to `VideoPlayerState` interface, invoked when playback reaches the end and `loop` is `false`
- Implement callback invocation on all 6 platforms: Android, iOS, Windows, macOS, Linux, Web/WASM
- Fix incorrect KDoc for `sliderPos` (was "0.0 to 1.0", corrected to "0.0 to 1000.0") and `seekTo`

## Test plan
- [x] Play a video to the end with `loop = false` and verify `onPlaybackEnded` is called
- [x] Play a video with `loop = true` and verify `onPlaybackEnded` is NOT called
- [x] Verify callback works on Android, iOS, Desktop (Win/Mac/Linux), and Web
- [x] Verify setting `onPlaybackEnded = null` does not cause crashes

Closes #152