### PR TITLE
feat: add duration property to VideoPlayerState

### DIFF
--- a/mediaplayer/src/androidMain/kotlin/io/github/kdroidfilter/composemediaplayer/VideoPlayerState.android.kt
+++ b/mediaplayer/src/androidMain/kotlin/io/github/kdroidfilter/composemediaplayer/VideoPlayerState.android.kt
@@ -58,6 +58,7 @@ actual fun createVideoPlayerState(audioMode: AudioMode): VideoPlayerState =
             positionText = "00:00",
             durationText = "00:00",
             currentTime = 0.0,
+            duration = 0.0,
             isFullscreen = false,
             aspectRatio = 16f / 9f,
             error =
@@ -267,6 +268,7 @@ open class DefaultVideoPlayerState(
     override val positionText: String get() = formatTime(_currentTime)
     override val durationText: String get() = formatTime(_duration)
     override val currentTime: Double get() = _currentTime
+    override val duration: Double get() = _duration
 
     override val isPipSupported: Boolean
         get() {

--- a/mediaplayer/src/commonMain/kotlin/io/github/kdroidfilter/composemediaplayer/VideoPlayerState.kt
+++ b/mediaplayer/src/commonMain/kotlin/io/github/kdroidfilter/composemediaplayer/VideoPlayerState.kt
@@ -73,6 +73,11 @@ interface VideoPlayerState {
      */
     val durationText: String
     val currentTime: Double
+
+    /**
+     * Returns the total duration of the media in seconds.
+     */
+    val duration: Double
     var isFullscreen: Boolean
     val aspectRatio: Float
 
@@ -190,6 +195,7 @@ data class PreviewableVideoPlayerState(
     override val positionText: String = "00:05",
     override val durationText: String = "00:10",
     override val currentTime: Double = 5000.0,
+    override val duration: Double = 10.0,
     override var isFullscreen: Boolean = false,
     override val aspectRatio: Float = 1.7f,
     override val error: VideoPlayerError? = null,

--- a/mediaplayer/src/iosMain/kotlin/io/github/kdroidfilter/composemediaplayer/VideoPlayerState.ios.kt
+++ b/mediaplayer/src/iosMain/kotlin/io/github/kdroidfilter/composemediaplayer/VideoPlayerState.ios.kt
@@ -169,6 +169,7 @@ open class DefaultVideoPlayerState(
     private var _currentTime: Double = 0.0
     private var _duration: Double = 0.0
     override val currentTime: Double get() = _currentTime
+    override val duration: Double get() = _duration
 
     // Observable video aspect ratio (default to 16:9)
     private var _videoAspectRatio by mutableStateOf(16.0 / 9.0)

--- a/mediaplayer/src/jvmMain/kotlin/io/github/kdroidfilter/composemediaplayer/VideoPlayerState.jvm.kt
+++ b/mediaplayer/src/jvmMain/kotlin/io/github/kdroidfilter/composemediaplayer/VideoPlayerState.jvm.kt
@@ -103,6 +103,7 @@ open class DefaultVideoPlayerState : VideoPlayerState {
     override val positionText: String get() = delegate.positionText
     override val durationText: String get() = delegate.durationText
     override val currentTime: Double get() = delegate.currentTime
+    override val duration: Double get() = delegate.duration
 
     override fun openUri(
         uri: String,

--- a/mediaplayer/src/jvmMain/kotlin/io/github/kdroidfilter/composemediaplayer/linux/LinuxVideoPlayerState.kt
+++ b/mediaplayer/src/jvmMain/kotlin/io/github/kdroidfilter/composemediaplayer/linux/LinuxVideoPlayerState.kt
@@ -112,6 +112,12 @@ class LinuxVideoPlayerState : VideoPlayerState {
                 if (hasMedia) getPositionSafely() else 0.0
             }
 
+    override val duration: Double
+        get() =
+            runBlocking {
+                if (hasMedia) getDurationSafely() else 0.0
+            }
+
     private val _aspectRatio = mutableStateOf(16f / 9f)
     override val aspectRatio: Float get() = _aspectRatio.value
 

--- a/mediaplayer/src/jvmMain/kotlin/io/github/kdroidfilter/composemediaplayer/mac/MacVideoPlayerState.kt
+++ b/mediaplayer/src/jvmMain/kotlin/io/github/kdroidfilter/composemediaplayer/mac/MacVideoPlayerState.kt
@@ -110,6 +110,12 @@ class MacVideoPlayerState : VideoPlayerState {
                 if (hasMedia) getPositionSafely() else 0.0
             }
 
+    override val duration: Double
+        get() =
+            runBlocking {
+                if (hasMedia) getDurationSafely() else 0.0
+            }
+
     // Non-blocking aspect ratio property
     private val _aspectRatio = mutableStateOf(16f / 9f)
     override val aspectRatio: Float get() = _aspectRatio.value

--- a/mediaplayer/src/jvmMain/kotlin/io/github/kdroidfilter/composemediaplayer/windows/WindowsVideoPlayerState.kt
+++ b/mediaplayer/src/jvmMain/kotlin/io/github/kdroidfilter/composemediaplayer/windows/WindowsVideoPlayerState.kt
@@ -223,6 +223,7 @@ class WindowsVideoPlayerState : VideoPlayerState {
     override val positionText: String get() = formatTime(_currentTime)
     override val durationText: String get() = formatTime(_duration)
     override val currentTime: Double get() = _currentTime
+    override val duration: Double get() = _duration
     private var errorMessage: String? by mutableStateOf(null)
 
     // Fullscreen state

--- a/mediaplayer/src/webMain/kotlin/io/github/kdroidfilter/composemediaplayer/VideoPlayerState.web.kt
+++ b/mediaplayer/src/webMain/kotlin/io/github/kdroidfilter/composemediaplayer/VideoPlayerState.web.kt
@@ -126,6 +126,7 @@ open class DefaultVideoPlayerState : VideoPlayerState {
     // Current time of the media in seconds
     private var _currentTime: Double = 0.0
     override val currentTime: Double get() = _currentTime
+    override val duration: Double get() = _currentDuration.toDouble()
 
     // Job for handling seek operations
     internal var seekJob: Job? = null


### PR DESCRIPTION
## Summary

- Add `duration: Double` property to `VideoPlayerState` interface, exposing the total media duration in seconds
- Implement across all platforms: Android, iOS, Web, JVM (Linux, Mac, Windows)
- Follows the same pattern as the existing `currentTime` property
- Keep `positionText` and `durationText` as-is for convenience

Closes #94

## Test plan

- [ ] Verify `duration` returns correct value in seconds on Android
- [ ] Verify `duration` returns correct value on JVM (Linux/Mac/Windows)
- [ ] Verify `duration` returns correct value on iOS
- [ ] Verify `duration` returns correct value on Web
- [ ] Verify `duration` is `0.0` when no media is loaded
- [ ] Verify `positionText` and `durationText` still work as before