### PR TITLE
fix: use BlendMode.Src for video frame rendering

### DIFF
--- a/mediaplayer/src/commonMain/kotlin/io/github/kdroidfilter/composemediaplayer/util/ContentScaleCanvasUtils.kt
+++ b/mediaplayer/src/commonMain/kotlin/io/github/kdroidfilter/composemediaplayer/util/ContentScaleCanvasUtils.kt
@@ -3,6 +3,7 @@ package io.github.kdroidfilter.composemediaplayer.util
 import androidx.compose.foundation.layout.*
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.BlendMode
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.layout.ContentScale
@@ -98,7 +99,8 @@ internal fun DrawScope.drawScaledImage(
             image = image,
             srcOffset = IntOffset(srcX, srcY),
             srcSize = IntSize(srcW, srcH),
-            dstSize = dstSize, // draw into full destination rect
+            dstSize = dstSize,
+            blendMode = BlendMode.Src,
         )
     } else {
         /* --------------------------------------------------------------
@@ -109,6 +111,7 @@ internal fun DrawScope.drawScaledImage(
         drawImage(
             image = image,
             dstSize = dstSize,
+            blendMode = BlendMode.Src,
         )
     }
 }


### PR DESCRIPTION
## Summary
- Use `BlendMode.Src` instead of default `SrcOver` when drawing video frames in `drawScaledImage()`
- Windows Media Foundation outputs BGRA frames with alpha = 0x00, causing video to blend with the background and appear washed out on light themes
- `BlendMode.Src` writes pixels directly without alpha blending, fixing the rendering on all backgrounds

Fixes #98

## Test plan
- [ ] Play a video on Windows with OS set to light mode — video should render at full opacity
- [ ] Play a video on Windows with dark mode — no regression
- [ ] Verify video playback on macOS and Linux — no regression
- [ ] Test all `ContentScale` modes (Fit, Crop, FillWidth, etc.)