### PR TITLE
feat: add openAsset() API for loading bundled media files

### DIFF
--- a/mediaplayer/src/androidMain/kotlin/io/github/kdroidfilter/composemediaplayer/VideoPlayerState.android.kt
+++ b/mediaplayer/src/androidMain/kotlin/io/github/kdroidfilter/composemediaplayer/VideoPlayerState.android.kt
@@ -634,6 +634,13 @@ open class DefaultVideoPlayerState(
         openFromMediaItem(mediaItem, initializeplayerState)
     }
 
+    override fun openAsset(
+        fileName: String,
+        initializeplayerState: InitialPlayerState,
+    ) {
+        openUri("asset:///$fileName", initializeplayerState)
+    }
+
     private fun openFromMediaItem(
         mediaItem: MediaItem,
         initializeplayerState: InitialPlayerState,

--- a/mediaplayer/src/commonMain/kotlin/io/github/kdroidfilter/composemediaplayer/VideoPlayerState.kt
+++ b/mediaplayer/src/commonMain/kotlin/io/github/kdroidfilter/composemediaplayer/VideoPlayerState.kt
@@ -174,7 +174,7 @@ interface VideoPlayerState {
     fun openAsset(
         fileName: String,
         initializeplayerState: InitialPlayerState = InitialPlayerState.PLAY,
-    ) = throw UnsupportedOperationException("openAsset is not supported on this platform")
+    ): Unit = throw UnsupportedOperationException("openAsset is not supported on this platform")
 
     // Error handling
     val error: VideoPlayerError?

--- a/mediaplayer/src/commonMain/kotlin/io/github/kdroidfilter/composemediaplayer/VideoPlayerState.kt
+++ b/mediaplayer/src/commonMain/kotlin/io/github/kdroidfilter/composemediaplayer/VideoPlayerState.kt
@@ -162,6 +162,20 @@ interface VideoPlayerState {
         initializeplayerState: InitialPlayerState = InitialPlayerState.PLAY,
     )
 
+    /**
+     * Opens a media file bundled with the application.
+     *
+     * On Android, plays directly from the APK's `assets/` directory via the `asset:///` URI scheme (zero-copy).
+     * On iOS, resolves the file from the app bundle via `NSBundle.mainBundle`.
+     *
+     * @param fileName the file name or relative path (e.g. `"video.mp4"` or `"videos/intro.mp4"`)
+     * @throws UnsupportedOperationException on platforms where asset loading is not yet supported
+     */
+    fun openAsset(
+        fileName: String,
+        initializeplayerState: InitialPlayerState = InitialPlayerState.PLAY,
+    ) = throw UnsupportedOperationException("openAsset is not supported on this platform")
+
     // Error handling
     val error: VideoPlayerError?
 

--- a/mediaplayer/src/iosMain/kotlin/io/github/kdroidfilter/composemediaplayer/VideoPlayerState.ios.kt
+++ b/mediaplayer/src/iosMain/kotlin/io/github/kdroidfilter/composemediaplayer/VideoPlayerState.ios.kt
@@ -742,6 +742,19 @@ open class DefaultVideoPlayerState(
         openUri(fileUrl, initializeplayerState)
     }
 
+    override fun openAsset(
+        fileName: String,
+        initializeplayerState: InitialPlayerState,
+    ) {
+        val name = fileName.substringBeforeLast(".")
+        val ext = fileName.substringAfterLast(".", "")
+        val path =
+            platform.Foundation.NSBundle.mainBundle
+                .pathForResource(name, ext.ifEmpty { null })
+                ?: throw IllegalArgumentException("Asset not found in app bundle: $fileName")
+        openUri("file://$path", initializeplayerState)
+    }
+
     override val metadata: VideoMetadata
         get() = _metadata
 


### PR DESCRIPTION
## Summary

Closes #96

- Add `openAsset(fileName)` to `VideoPlayerState` interface for playing media directly from app-bundled assets without file copying
- **Android**: uses the `asset:///` URI scheme natively supported by ExoPlayer (zero-copy playback from APK)
- **iOS**: resolves the file from the app bundle via `NSBundle.mainBundle.pathForResource()`
- **Other platforms**: throws `UnsupportedOperationException` (can be extended later)

### Usage

```kotlin
playerState.openAsset("video.mp4")
playerState.openAsset("videos/intro.mp4")
```

## Test plan

- [ ] Android: place a video in `assets/`, call `openAsset("video.mp4")`, verify playback
- [ ] iOS: add a video to the app bundle, call `openAsset("video.mp4")`, verify playback
- [ ] Verify calling `openAsset()` on unsupported platforms throws `UnsupportedOperationException`
- [x] ktlint passes