### PR TITLE
fix(windows): prevent use-after-free crash in Skia bitmap during dispose

### DIFF
--- a/mediaplayer/src/jvmMain/kotlin/io/github/kdroidfilter/composemediaplayer/windows/WindowsVideoPlayerState.kt
+++ b/mediaplayer/src/jvmMain/kotlin/io/github/kdroidfilter/composemediaplayer/windows/WindowsVideoPlayerState.kt
@@ -346,19 +346,10 @@ class WindowsVideoPlayerState : VideoPlayerState {
 
         // Free bitmaps and frame buffers
         bitmapLock.write {
-            val currentFrame = _currentFrame
-            if (currentFrame != null &&
-                currentFrame !== skiaBitmapA &&
-                currentFrame !== skiaBitmapB
-            ) {
-                currentFrame.close()
-            }
             _currentFrame = null
             currentFrameState.value = null
 
-            // Clean up double-buffering bitmaps
-            skiaBitmapA?.close()
-            skiaBitmapB?.close()
+            // Don't close bitmaps — see comment in releaseAllResources().
             skiaBitmapA = null
             skiaBitmapB = null
             skiaBitmapWidth = 0
@@ -391,19 +382,16 @@ class WindowsVideoPlayerState : VideoPlayerState {
 
         // Free bitmaps and frame buffers
         bitmapLock.write {
-            val currentFrame = _currentFrame
-            if (currentFrame != null &&
-                currentFrame !== skiaBitmapA &&
-                currentFrame !== skiaBitmapB
-            ) {
-                currentFrame.close()
-            }
             _currentFrame = null
             currentFrameState.value = null
 
-            // Clean up double-buffering bitmaps
-            skiaBitmapA?.close()
-            skiaBitmapB?.close()
+            // Do NOT close the double-buffer bitmaps here: the ImageBitmap
+            // exposed via currentFrameState shares the same native pixel memory
+            // (asComposeImageBitmap is zero-copy). Compose may still be rendering
+            // the last frame on the AWT-EventQueue thread. Closing now would free
+            // the native memory while Skia reads it, causing an access violation.
+            // Nullifying the references lets the Skia Managed cleaner release them
+            // once Compose (and any other holder) drops its reference.
             skiaBitmapA = null
             skiaBitmapB = null
             skiaBitmapWidth = 0


### PR DESCRIPTION
## Summary

- **Fix JVM crash** (`EXCEPTION_ACCESS_VIOLATION` in `skiko-windows-x64.dll`) occurring when playback ends or the player is disposed
- `asComposeImageBitmap()` is zero-copy — the resulting `ImageBitmap` shares native pixel memory with the source `Bitmap`. When `dispose()` called `close()` on the double-buffer bitmaps, Compose could still be rendering the last frame on the AWT-EventQueue thread, causing `_nMakeFromBitmap` to read freed memory
- Instead of explicitly closing bitmaps, nullify references and let the Skia `Managed` cleaner free them once all holders (including Compose) drop their references — no memory leak, just ~50ms deferred cleanup

## Test plan

- [x] Play a video to completion (non-loop mode) — no crash after "Playback ended"
- [x] Dispose the player mid-playback — no crash
- [x] Play multiple videos in sequence — no memory leak accumulation
- [x] Loop mode still works correctly