### PR TITLE
fix(mac): apply rotation metadata and reach 100% on progress bar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,8 @@ Pods/
 /mediaplayer/src/jvmMain/resources/composemediaplayer/native/
 /mediaplayer/src/jvmMain/resources/win32-x86-64/
 /mediaplayer/src/jvmMain/resources/win32-arm64/
+/mediaplayer/src/jvmMain/resources/darwin-aarch64/
+/mediaplayer/src/jvmMain/resources/darwin-x86-64/
 
 # Native build artifacts
 /mediaplayer/src/jvmMain/native/windows/build-x64/

--- a/mediaplayer/src/jvmMain/kotlin/io/github/kdroidfilter/composemediaplayer/mac/MacVideoPlayerState.kt
+++ b/mediaplayer/src/jvmMain/kotlin/io/github/kdroidfilter/composemediaplayer/mac/MacVideoPlayerState.kt
@@ -681,22 +681,23 @@ class MacVideoPlayerState : VideoPlayerState {
             }
 
             // Check for looping
-            checkLoopingAsync(current, duration)
+            checkLoopingAsync()
         } catch (e: Exception) {
             if (e is CancellationException) throw e
             macLogger.e { "Error in updatePositionAsync: ${e.message}" }
         }
     }
 
-    /** Checks if looping is enabled and restarts the video if needed. */
-    private suspend fun checkLoopingAsync(
-        current: Double,
-        duration: Double,
-    ) {
+    /** Checks if playback has ended and triggers loop or stop accordingly. */
+    private suspend fun checkLoopingAsync() {
         val ptr = playerPtr
-        val ended = ptr != 0L && MacNativeBridge.nConsumeDidPlayToEnd(ptr)
-        // Also check position as fallback for content where the notification may not fire
-        if (!ended && (duration <= 0 || current < duration - 0.5)) return
+        if (ptr == 0L) return
+
+        // Trust AVPlayerItemDidPlayToEndTime: it fires reliably on macOS for both
+        // file and HLS playback. A position-based fallback (current >= duration - x)
+        // is dangerous because it stops playback x seconds early — the slider
+        // freezes at (duration - x) / duration instead of reaching 100%.
+        if (!MacNativeBridge.nConsumeDidPlayToEnd(ptr)) return
 
         if (loop) {
             macLogger.d { "checkLoopingAsync() - Loop enabled, restarting video" }

--- a/mediaplayer/src/jvmMain/native/macos/NativeVideoPlayer.swift
+++ b/mediaplayer/src/jvmMain/native/macos/NativeVideoPlayer.swift
@@ -747,15 +747,22 @@ class MacVideoPlayer {
                         self.nativeVideoWidth = self.frameWidth
                         self.nativeVideoHeight = self.frameHeight
 
+                        // Build a video composition that applies the preferred transform so
+                        // that AVPlayerItemVideoOutput delivers pixel buffers already rotated
+                        // to display orientation (fixes portrait videos rendering sideways).
+                        let videoComposition: AVVideoComposition? = self.isHLSStream
+                            ? nil
+                            : (try? await AVVideoComposition.videoComposition(withPropertiesOf: asset))
+
                         // Continue with player setup
-                        self.setupVideoOutputAndPlayer(with: asset)
+                        self.setupVideoOutputAndPlayer(with: asset, videoComposition: videoComposition)
                     } catch {
                         print("Error loading video track properties: \(error.localizedDescription)")
                         // Use default dimensions for HLS if loading fails
                         if self.isHLSStream {
                             self.frameWidth = 1920
                             self.frameHeight = 1080
-                            self.setupVideoOutputAndPlayer(with: asset)
+                            self.setupVideoOutputAndPlayer(with: asset, videoComposition: nil)
                         }
                     }
                 }
@@ -770,8 +777,14 @@ class MacVideoPlayer {
                 nativeVideoWidth = frameWidth
                 nativeVideoHeight = frameHeight
 
+                // Build a video composition that applies the preferred transform (see modern
+                // path above for rationale). Skip for HLS streams.
+                let videoComposition: AVVideoComposition? = isHLSStream
+                    ? nil
+                    : AVMutableVideoComposition(propertiesOf: asset)
+
                 // Continue with player setup
-                setupVideoOutputAndPlayer(with: asset)
+                setupVideoOutputAndPlayer(with: asset, videoComposition: videoComposition)
             }
         }
     }
@@ -825,7 +838,7 @@ class MacVideoPlayer {
     }
 
     // Helper method to setup video output and player
-    private func setupVideoOutputAndPlayer(with asset: AVAsset) {
+    private func setupVideoOutputAndPlayer(with asset: AVAsset, videoComposition: AVVideoComposition? = nil) {
         // Create attributes for the CVPixelBuffer (BGRA format) with IOSurface for better performance
         let pixelBufferAttributes: [String: Any] = [
             kCVPixelBufferPixelFormatTypeKey as String: kCVPixelFormatType_32BGRA,
@@ -836,6 +849,12 @@ class MacVideoPlayer {
         videoOutput = AVPlayerItemVideoOutput(pixelBufferAttributes: pixelBufferAttributes)
 
         let item = AVPlayerItem(asset: asset)
+
+        // Apply the video composition (if any) so that pixel buffers delivered to
+        // AVPlayerItemVideoOutput are pre-rotated to the display orientation.
+        if let videoComposition = videoComposition {
+            item.videoComposition = videoComposition
+        }
 
         // Configure for HLS if needed
         if isHLSStream {


### PR DESCRIPTION
## Summary

- **Portrait videos no longer render sideways on JVM/macOS** (#202). Set an `AVVideoComposition` (built from the asset's preferred transform) on the `AVPlayerItem` so `AVPlayerItemVideoOutput` delivers pixel buffers already rotated to display orientation. Skipped for HLS streams whose tracks aren't synchronously available.
- **Progress bar now reaches the end of the video.** The `checkLoopingAsync` had a 0.5 s position-based fallback that triggered `pauseInBackground()` half a second before the real end, freezing `sliderPos` at `(duration - 0.5) / duration` — visibly short for short videos. Removed the fallback; we now trust `AVPlayerItemDidPlayToEndTime`, which fires reliably on macOS for both file and HLS playback.
- gitignore the prebuilt `darwin-aarch64/` and `darwin-x86-64/` dylib resource directories so they don't accidentally get committed.

## Test plan

- [x] Open a portrait video recorded on a phone (e.g. the sample from #202) — it should render upright instead of sideways.
- [x] Verify aspect ratio remains correct for landscape videos.
- [x] Play a short video to completion — the progress slider should visibly reach 100% before pausing.
- [x] Loop mode: enable loop on a short video and confirm seamless restart.
- [x] HLS playback still works (no composition is applied; behavior unchanged).
- [x] Rebuild dylibs via `mediaplayer/src/jvmMain/native/macos/build.sh` for both `arm64` and `x86_64` and confirm clean compilation.