### PR TITLE
Only sign publications in CI

### DIFF
--- a/mediaplayer/build.gradle.kts
+++ b/mediaplayer/build.gradle.kts
@@ -256,5 +256,10 @@ mavenPublishing {
     }
 
     publishToMavenCentral()
-    signAllPublications()
+
+    // Only sign publications in CI environments to avoid requiring local GPG signing setup.
+    if (System.getenv("CI") != null) {
+        signAllPublications()
+    }
+
 }


### PR DESCRIPTION
This PR limits publication signing to CI environments only.

Previously, local builds also required signing configuration, which caused `publishToMavenLocal` to fail when no local GPG signatory was configured.

Since artifact signing is mainly necessary for `CI/release` publishing workflows, this change skips signing during local development while preserving signing behavior in CI environments.

This also makes local testing and Maven local publishing easier for contributors.