### PR TITLE
Update dependencies and drop iosX64 from audioplayer

### DIFF
--- a/audioplayer/build.gradle.kts
+++ b/audioplayer/build.gradle.kts
@@ -32,7 +32,6 @@ kotlin {
         binaries.executable()
     }
 
-    iosX64()
     iosArm64()
     iosSimulatorArm64()
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,19 +1,19 @@
 [versions]
 
 androidcontextprovider = "1.0.1"
-filekit = "0.14.0"
-kotlin = "2.3.20"
+filekit = "0.14.2"
+kotlin = "2.4.0"
 agp = "8.13.2"
-kotlinx-coroutines = "1.10.2"
+kotlinx-coroutines = "1.11.0"
 kotlinxBrowserWasmJs = "0.5.0"
-kotlinxDatetime = "0.7.1"
-compose = "1.10.3"
+kotlinxDatetime = "0.8.0"
+compose = "1.11.1"
 androidx-activityCompose = "1.13.0"
-androidx-core = "1.18.0"
-media3Exoplayer = "1.10.0"
+androidx-core = "1.19.0"
+media3Exoplayer = "1.10.1"
 detekt = "1.23.8"
 ktlint = "14.2.0"
-androidx-lifecycle-runtime-ktx = "2.10.0"
+androidx-lifecycle-runtime-ktx = "2.11.0"
 jna = "5.18.1"
 platformtoolsDarkmodedetector = "0.7.4"
 rodio = "1.0.0"
@@ -65,8 +65,8 @@ android-library = { id = "com.android.library", version.ref = "agp" }
 compose = { id = "org.jetbrains.compose", version.ref = "compose" }
 compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 android-application = { id = "com.android.application", version.ref = "agp" }
-vannitktech-maven-publish = {id = "com.vanniktech.maven.publish", version = "0.36.0"}
+vannitktech-maven-publish = {id = "com.vanniktech.maven.publish", version = "0.37.0"}
 dokka = { id = "org.jetbrains.dokka" , version = "2.2.0"}
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
 ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlint" }
-nucleus = { id = "io.github.kdroidfilter.nucleus", version = "1.9.1" }
+nucleus = { id = "io.github.kdroidfilter.nucleus", version = "1.15.7" }


### PR DESCRIPTION
## Summary
- Bump Kotlin 2.3.20 → 2.4.0, Compose Multiplatform 1.10.3 → 1.11.1, FileKit 0.14.0 → 0.14.2
- Bump kotlinx-coroutines 1.10.2 → 1.11.0, kotlinx-datetime 0.7.1 → 0.8.0
- Bump androidx-core 1.18.0 → 1.19.0, media3 1.10.0 → 1.10.1, lifecycle-runtime-ktx 2.10.0 → 2.11.0
- Bump vanniktech maven-publish 0.36.0 → 0.37.0, nucleus 1.9.1 → 1.15.7
- Remove the `iosX64()` target from `:audioplayer`: Compose 1.11.1 and FileKit 0.14.2 no longer publish `ios_x64` variants, which broke dependency resolution during IDE import. This aligns `audioplayer` with `mediaplayer` and the sample app, which already only declare `iosArm64` and `iosSimulatorArm64`.

## Test plan
- [x] `./gradlew :audioplayer:prepareKotlinIdeaImport` passes (previously failed with 7 variant-resolution errors)
- [ ] Gradle sync succeeds in the IDE
- [ ] CI builds all targets