### PR TITLE
fix: parse WebVTT cues with settings

### DIFF
--- a/mediaplayer/src/commonMain/kotlin/io/github/kdroidfilter/composemediaplayer/subtitle/WebVttParser.kt
+++ b/mediaplayer/src/commonMain/kotlin/io/github/kdroidfilter/composemediaplayer/subtitle/WebVttParser.kt
@@ -35,8 +35,10 @@ object WebVttParser {
         val cues = mutableListOf<SubtitleCue>()
         var i = 0
 
-        // Skip header and empty lines
-        while (i < lines.size && !CUE_TIMING_PATTERN.matches(lines[i])) {
+        // Skip header and metadata until the first cue timing line. A timing line may contain
+        // WebVTT cue settings after the end timestamp, so it does not necessarily fully match
+        // the timestamp-only pattern.
+        while (i < lines.size && CUE_TIMING_PATTERN.find(lines[i]) == null) {
             i++
         }
 

--- a/mediaplayer/src/commonTest/kotlin/io/github/kdroidfilter/composemediaplayer/subtitle/WebVttParserTest.kt
+++ b/mediaplayer/src/commonTest/kotlin/io/github/kdroidfilter/composemediaplayer/subtitle/WebVttParserTest.kt
@@ -1,0 +1,33 @@
+package io.github.kdroidfilter.composemediaplayer.subtitle
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class WebVttParserTest {
+    @Test
+    fun parsesCuesWithSettings() {
+        val content =
+            """
+            WEBVTT
+
+            STYLE
+            ::cue(.combine) { text-combine-upright: all; }
+
+            00:00:01.000 --> 00:00:03.000 line:0
+            Top
+
+            00:00:04.000 --> 00:00:06.000 vertical:rl line:5%
+            Vertical
+            """.trimIndent()
+
+        val subtitles = WebVttParser.parse(content)
+
+        assertEquals(2, subtitles.cues.size)
+        assertEquals(1_000, subtitles.cues[0].startTime)
+        assertEquals(3_000, subtitles.cues[0].endTime)
+        assertEquals("Top", subtitles.cues[0].text)
+        assertEquals(4_000, subtitles.cues[1].startTime)
+        assertEquals(6_000, subtitles.cues[1].endTime)
+        assertEquals("Vertical", subtitles.cues[1].text)
+    }
+}


### PR DESCRIPTION
## Summary

- allow WebVTT cue timing lines to contain standard cue settings
- preserve existing parsing behavior for timing and subtitle text
- add regression coverage for STYLE metadata and `line`/`vertical` settings

Previously, the parser required the first timing line to fully match a timestamp-only regex. Valid lines such as:

`00:00:01.000 --> 00:00:03.000 line:0`

were skipped, resulting in an empty cue list.

## Testing

- `./gradlew :mediaplayer:jvmTest --tests 'io.github.kdroidfilter.composemediaplayer.subtitle.WebVttParserTest'`
- `./gradlew :mediaplayer:ktlintCheck`

## Reproduction samples

These public WebVTT files reproduce the issue:

- [Positioned numeric cues](https://storage.googleapis.com/exoplayer-test-media-1/webvtt/numeric-lines.vtt)
- [Japanese vertical cues](https://storage.googleapis.com/exoplayer-test-media-1/webvtt/japanese.vtt)

They contain valid cue settings such as `line:0`, `line:-1`, and `vertical:rl`. Previously, the parser skipped the first timing line because it required the timestamp-only pattern to match the entire line.